### PR TITLE
Add platform info to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,14 +75,30 @@ CITS5505Group3/
 
 1. Install **Python 3.13** 🐍.
 2. Create and activate your Python environment (optional):  
-    ```
+
+    ```bash
     python -m venv application-env
-    cd application-env/Scripts
-    activate.bat (cmd) or activate.ps1 (PowerShell) or activate (bash)
     ```
+
+    Activate the virtual environment:  
+
+    - **For CMD**:  
+      ```cmd
+      application-env\Scripts\activate.bat
+      ```
+
+    - **For PowerShell**:  
+      ```powershell
+      application-env\Scripts\activate.ps1
+      ```
+
+    - **For Bash (Linux/Mac)**:  
+      ```bash
+      source application-env/bin/activate
+      ```
 3. Install required modules:  
     ```
-    pip install -r requirements.txt
+    python -m pip install -r requirements.txt
     ```
 4. For the first time, run in the codebase root directory:  
     ```
@@ -91,15 +107,15 @@ CITS5505Group3/
 
 5. Add SECRET_KEY to ENV (Please replace with your own key string!):
 
-    Linux: 
+    - **For Bash (Linux/Mac)**:  
     ```
     export SECRET_KEY='YOUROWNKEY'
     ```
-    CMD: 
+    - **For CMD**:  
     ```
     set SECRET_KEY=YOUROWNKEY
     ```
-    Powershell: 
+    - **For PowerShell**:  
     ```
     $env:SECRET_KEY = "YOUROWNKEY"
     ```


### PR DESCRIPTION
This pull request updates the `README.md` file in the `CITS5505Group3` directory to improve clarity and platform-specific instructions for setting up the Python environment and configuring the `SECRET_KEY`.

### Improvements to setup instructions:

* Enhanced the virtual environment activation steps by providing separate instructions for CMD, PowerShell, and Bash (Linux/Mac). This ensures platform-specific clarity for users. (`[README.mdL78-R101](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L78-R101)`)

* Updated the `SECRET_KEY` setup instructions with distinct sections for each platform (Bash, CMD, and PowerShell), making it easier for users to follow the correct steps based on their environment. (`[README.mdL94-R118](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L94-R118)`)Add commands environment info to Readme for new beginners